### PR TITLE
issue on clean task

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -49,7 +49,7 @@ gulp.task('watch', function () {
 });
 
 gulp.task('clean', function(cb) {
-  del(['dist'], cb);
+  del(['/dist'], cb);
 });
 
 gulp.task('scripts', ['clean'], function() {


### PR DESCRIPTION

Hi,
There is an issue with the clean task. it should be like this:
del(['/dist'], cb);

The "/" is missing so it will throw an error.

I want to tell you that this is a awesome generator, thank you and keep going on it.
You save me a lot of time.